### PR TITLE
Fix ClearStackAndPush in Android

### DIFF
--- a/Droid/src/QodenController.cs
+++ b/Droid/src/QodenController.cs
@@ -202,9 +202,11 @@ namespace Qoden.UI
             if (FragmentManager.BackStackEntryCount > 0)
             {
                 var id = FragmentManager.GetBackStackEntryAt(0).Id;
-                FragmentManager.PopBackStackImmediate(id, FragmentManager.PopBackStackInclusive);
+                FragmentManager.PopBackStack(id, FragmentManager.PopBackStackInclusive);
             }
-            Push(controller);
+            FragmentManager.BeginTransaction()
+                .Replace(Id, controller)
+                .Commit();
         }
 
         public void Push(QodenController controller)


### PR DESCRIPTION
1. Do not PopBackStack Immediate (because current controller will be replaced and its FragmentManager will be null, which will lead to NullReferenceException)
2. Do not add current controller replacement to back stack