### PR TITLE
Pass Type.Name of controller instead of Tag to AddBackStack 

### DIFF
--- a/Droid/src/QodenController.cs
+++ b/Droid/src/QodenController.cs
@@ -247,7 +247,7 @@ namespace Qoden.UI
         {
             FragmentManager.BeginTransaction()
                            .Replace(Id, controller)
-                           .AddToBackStack(controller.Tag)
+                           .AddToBackStack(controller.GetType().Name)
                            .Commit();
         }
 


### PR DESCRIPTION
It is needed because at that time Tag is always null and useless. 
Unique value passed to AddToBackStack allows us to use PopBackStack(string, int) to pop until specific controller.