### PR TITLE
Refactor action bar in Android

### DIFF
--- a/Droid/src/QodenController.cs
+++ b/Droid/src/QodenController.cs
@@ -63,6 +63,7 @@ namespace Qoden.UI
                 Logger.LogInformation("OnViewCreated (ViewDidLoad)");
 
             base.OnViewCreated(view, savedInstanceState);
+            ToolbarVisible = false;
             if (!_view.DidLoad)
             {
                 _view.DidLoad = true;
@@ -76,11 +77,18 @@ namespace Qoden.UI
             set => _view.Value = value;
         }
 
+        private string _title = "";
         public string Title
         {
-            get => Activity?.Title;
-            set => Activity.Title = value;
+            get => _title;
+            set
+            {
+                _title = value;
+                Activity.Title = _title;
+            }
         }
+
+        public Action ConfigureActionBarAction { get; set; }
 
         List<MenuItemInfo> menuItems = new List<MenuItemInfo>();
         public List<MenuItemInfo> MenuItems
@@ -106,11 +114,6 @@ namespace Qoden.UI
                             Side = Side.Left
                         };
                     }
-                }
-
-                if (menuItems.All(menuItem => menuItem.Side != Side.Left))
-                {
-                    ((AppCompatActivity) Activity).SupportActionBar.SetDisplayHomeAsUpEnabled(false);
                 }
 
                 HasOptionsMenu = menuItems.Count > 0;
@@ -182,6 +185,13 @@ namespace Qoden.UI
                         compatActivity.SupportActionBar.Hide();
                     }
                 }
+
+                if (ConfigureActionBarAction == null)
+                    ConfigureActionBarAction = () =>
+                    {
+                        ToolbarVisible = true;
+                        Activity.Title = Title ?? "";
+                    };
             }
         }
 
@@ -219,6 +229,7 @@ namespace Qoden.UI
                 Bindings.UpdateTarget();
             }
             ViewWillAppear();
+            ConfigureActionBarAction?.Invoke();
         }
 
         public sealed override void OnPause()
@@ -229,6 +240,12 @@ namespace Qoden.UI
             base.OnPause();
             Bindings.Unbind();
             ViewWillDisappear();
+        }
+
+        public override void OnDestroyView()
+        {
+            base.OnDestroyView();
+            ((AppCompatActivity) Activity).SupportActionBar.SetDisplayHomeAsUpEnabled(false);
         }
 
         public void ClearStackAndPush(QodenController controller)

--- a/Droid/src/QodenController.cs
+++ b/Droid/src/QodenController.cs
@@ -186,12 +186,14 @@ namespace Qoden.UI
                     }
                 }
 
-                if (ConfigureActionBarAction == null)
+                if (value && ConfigureActionBarAction == null)
                     ConfigureActionBarAction = () =>
                     {
                         ToolbarVisible = true;
                         Activity.Title = Title ?? "";
                     };
+                else if (!value)
+                    ConfigureActionBarAction = null;
             }
         }
 

--- a/Droid/src/QodenController.cs
+++ b/Droid/src/QodenController.cs
@@ -157,7 +157,7 @@ namespace Qoden.UI
         {
             var itemInfo = MenuItems.Find(info => info.Id == item.ItemId);
             var command = itemInfo.Command;
-            if(command != null) 
+            if (command != null)
             {
                 command.Execute();
                 return true;
@@ -256,8 +256,8 @@ namespace Qoden.UI
                 FragmentManager.PopBackStack(id, FragmentManager.PopBackStackInclusive);
             }
             FragmentManager.BeginTransaction()
-                .Replace(Id, controller)
-                .Commit();
+                           .Replace(Id, controller)
+                           .Commit();
         }
 
         public void Push(QodenController controller)
@@ -290,8 +290,7 @@ namespace Qoden.UI
         /// Override this instead on CreateView
         /// </summary>
         public virtual void LoadView()
-        {
-        }
+        { }
     }
 
     public class QodenController<T> : QodenController where T : Android.Views.View

--- a/Droid/src/QodenController.cs
+++ b/Droid/src/QodenController.cs
@@ -63,7 +63,10 @@ namespace Qoden.UI
                 Logger.LogInformation("OnViewCreated (ViewDidLoad)");
 
             base.OnViewCreated(view, savedInstanceState);
-            ToolbarVisible = false;
+
+            if (ConfigureActionBarAction == null)
+                ToolbarVisible = false;
+
             if (!_view.DidLoad)
             {
                 _view.DidLoad = true;

--- a/Shared/Wrappers/ActionBar.cs
+++ b/Shared/Wrappers/ActionBar.cs
@@ -33,12 +33,12 @@ namespace Qoden.UI.Wrappers
                 };
             }
 #elif __ANDROID__
-            var typeface = TypefaceCollection.Get(font.Name, font.Style);
-            var fontSize = new AbsoluteSizeSpan((int) font.Size.Dp());
+            var typefaceSpan = new CustomTypefaceSpan(TypefaceCollection.Get(font.Name, font.Style));
+            var fontSizeSpan = new AbsoluteSizeSpan((int) font.Size.Dp());
 
             var spannableString = new SpannableString(PlatformView.Title);
-            spannableString.SetSpan(new CustomTypefaceSpan(typeface), 0, spannableString.Length(), 0);
-            spannableString.SetSpan(fontSize, 0, spannableString.Length(), 0);
+            spannableString.SetSpan(typefaceSpan, 0, spannableString.Length(), 0);
+            spannableString.SetSpan(fontSizeSpan, 0, spannableString.Length(), 0);
 
             PlatformView.TitleFormatted = spannableString;
 #endif
@@ -92,7 +92,7 @@ namespace Qoden.UI.Wrappers
     }
     public static class ActionBarExtensions
     {
-        public static ActionBar GetActionBar(this QodenController controller, bool addSubview = true)
+        public static ActionBar GetActionBar(this QodenController controller)
         {
 #if __IOS__
             return controller.NavigationController.NavigationBar.AsActionBar();


### PR DESCRIPTION
@Dragollla16 @crash481 
This PR hides some differences between how action bar works in iOS and Android. 
Now each controller will have its own Title and MenuItems that won't be preserved in pushed/popped controllers - same as in iOS. 
Custom action bar configuration now can be done in ViewDidLoad. In Android it should be this way:
```
 qodenController.ConfigureActionBarAction += () =>
 {
    qodenController.GetActionBar().SetTextColor(...);
    qodenController.GetActionBar().SetFont(...);
    //etc...
}
```

@Dragollla16 Also, how about rearranging some methods and properties in Droid.QodenController? It's a little mixed up at the moment